### PR TITLE
Preserve whitelist and Makefile when limiting tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,9 +221,11 @@ jobs:
         if: true
         run: |
           cd mlton
+          mv regression/whitelist .
           mv regression/real.* .
           mv regression/real-basic.* .
           rm -r regression/*
+          mv whitelist regression/
           mv real.* regression/
           mv real-basic.* regression/
           mv benchmark/tests/raytrace.sml .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,10 +221,12 @@ jobs:
         if: true
         run: |
           cd mlton
+          mv regression/Makefile Makefile.regression
           mv regression/whitelist .
           mv regression/real.* .
           mv regression/real-basic.* .
           rm -r regression/*
+          mv Makefile.regression regression/Makefile
           mv whitelist regression/
           mv real.* regression/
           mv real-basic.* regression/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,8 +230,10 @@ jobs:
           mv whitelist regression/
           mv real.* regression/
           mv real-basic.* regression/
+          mv benchmark/tests/Makefile Makefile.benchmark.tests
           mv benchmark/tests/raytrace.sml .
           rm -r benchmark/tests/*
+          mv Makefile.benchmark.tests benchmark/tests/Makefile
           mv raytrace.sml benchmark/tests/
 
       - name: Test


### PR DESCRIPTION
The "failures" with https://github.com/ii8/mlton-builds/actions/runs/6889290651 are just due to the `real` regression test having low-bit differences with the reference output, which is usually not flagged as a failure due to the `regression/whitelist`.
